### PR TITLE
Fix compatibility with Python 2

### DIFF
--- a/ipyvolume/transferfunction.py
+++ b/ipyvolume/transferfunction.py
@@ -28,7 +28,7 @@ if 0:
 
 	array_serialization = dict(to_json=array_to_json, from_json=array_from_json)
 
-@widgets.register
+@widgets.register()
 class TransferFunction(widgets.DOMWidget):
 	_model_name = Unicode('TransferFunctionModel').tag(sync=True)
 	_view_name = Unicode('TransferFunctionView').tag(sync=True)

--- a/ipyvolume/widgets.py
+++ b/ipyvolume/widgets.py
@@ -20,7 +20,7 @@ _last_volume_renderer = None
 import ipyvolume._version
 semver_range_frontend = "~" + ipyvolume._version.__version_js__
 
-@widgets.register
+@widgets.register()
 class Mesh(widgets.DOMWidget):
     _view_name = Unicode('MeshView').tag(sync=True)
     _view_module = Unicode('ipyvolume').tag(sync=True)
@@ -56,7 +56,7 @@ class Mesh(widgets.DOMWidget):
 
     side = traitlets.CaselessStrEnum(['front', 'back', 'both'], 'both').tag(sync=True)
 
-@widgets.register
+@widgets.register()
 class Scatter(widgets.DOMWidget):
     _view_name = Unicode('ScatterView').tag(sync=True)
     _view_module = Unicode('ipyvolume').tag(sync=True)
@@ -90,7 +90,7 @@ class Scatter(widgets.DOMWidget):
 
 
 
-@widgets.register
+@widgets.register()
 class Figure(ipywebrtc.MediaStream):
     """Widget class representing a volume (rendering) using three.js"""
     _view_name = Unicode('FigureView').tag(sync=True)


### PR DESCRIPTION
This PR fixes a compatibility issue with Python 2: decorating with just `@widgets.register` will transform the decorated class into a function, whereas using `@widgets.register()` will correctly return a class. I could successfully run the example:

```python
import ipyvolume
ipyvolume.examples.ball(rmax=3, rmin=2.5, shape=64, lighting=True)
```

BTW it would be nice I think to add the [mybinder examples](https://hub.mybinder.org/user/maartenbreddels-ipyvolume-ew8oywwc/notebooks/notebooks/simple.ipynb) in the doc directly, or even the readme, so that new users can easily test out the widget for themselves :-) Otherwise in the doc there is no other example that does not require a 3rd-party library (bokeh etc).