### PR TITLE
Added support for ipv.figure(ipv.Figure) syntax

### DIFF
--- a/ipyvolume/pylab.py
+++ b/ipyvolume/pylab.py
@@ -13,6 +13,8 @@ from . import examples
 import warnings
 import PIL.Image
 import traitlets
+import uuid
+
 try:
     from io import BytesIO as StringIO
 except:
@@ -77,13 +79,19 @@ def figure(key=None, width=400, height=500, lighting=True, controls=True, contro
     if key is not None and key in current.figures:
         current.figure = current.figures[key]
         current.container = current.containers[key]
+    elif isinstance(key, ipv.Figure) and key in current.figures.values():
+        key_index = list(current.figures.values()).index(key)
+        key = list(current.figures.keys())[key_index]
+        current.figure = current.figures[key]
+        current.container = current.containers[key]
     else:
         current.figure = ipv.Figure(volume_data=None, width=width, height=height, **kwargs)
         current.container = ipywidgets.VBox()
         current.container.children = [current.figure]
-        if key is not None:
-            current.figures[key] = current.figure
-            current.containers[key] = current.container
+        if key is None:
+            key = uuid.uuid4().hex
+        current.figures[key] = current.figure
+        current.containers[key] = current.container
         if controls:
             #stereo = ipywidgets.ToggleButton(value=current.figure.stereo, description='stereo', icon='eye')
             #l1 = ipywidgets.jslink((current.figure, 'stereo'), (stereo, 'value'))

--- a/ipyvolume/test_all.py
+++ b/ipyvolume/test_all.py
@@ -39,16 +39,6 @@ def test_figure():
     p3.clear()
     f6 = p3.gcf()
     
-    f7 = p3.figure('f7')
-    f8 = p3.figure()
-    f9 = p3.figure('f7')
-    f10 = p3.figure(f8)
-    f11 = p3.gcf()
-    f12 = p3.current.figure
-    f13 = p3.figure('f7')
-    f14 = p3.current.figures['f7']
-    f15 = p3.current.figures[f7]
-
     assert f1 != f2
     assert f2 != f3
     assert f3 != f4
@@ -56,14 +46,21 @@ def test_figure():
     assert f4 == f5
     assert f5 != f6
     
+    f7 = p3.figure('f7')
+    f8 = p3.figure()
+    f9 = p3.figure('f7')
+    f10 = p3.figure(f8)
+    f11 = p3.gcf()
+    f12 = p3.current.figure
+    f13 = p3.figure('f7')
+    f14 = p3.current.figures['f7'] 
+   
     assert f7 == f9
     assert f8 == f10
     assert f10 == f11
     assert f11 == f12
     assert f13 == f14
-    assert f13 == f15
     
-
     for controls in [True, False]:
         for debug in [True, False]:
             p3.figure(debug=debug, controls=controls)

--- a/ipyvolume/test_all.py
+++ b/ipyvolume/test_all.py
@@ -38,6 +38,16 @@ def test_figure():
     f5 = p3.gcf()
     p3.clear()
     f6 = p3.gcf()
+    
+    f7 = p3.figure('f7')
+    f8 = p3.figure()
+    f9 = p3.figure('f7')
+    f10 = p3.figure(f8)
+    f11 = p3.gcf()
+    f12 = p3.current.figure
+    f13 = p3.figure('f7')
+    f14 = p3.current.figures['f7']
+    f15 = p3.current.figures[f7]
 
     assert f1 != f2
     assert f2 != f3
@@ -45,6 +55,14 @@ def test_figure():
     assert f2 == f2
     assert f4 == f5
     assert f5 != f6
+    
+    assert f7 == f9
+    assert f8 == f10
+    assert f10 == f11
+    assert f11 == f12
+    assert f13 == f14
+    assert f13 == f15
+    
 
     for controls in [True, False]:
         for debug in [True, False]:


### PR DESCRIPTION
In reference to this issue: #105 

Downside of all the Figure handling atm is that one has to take care not to accidentally use ipv.Figure instead of ipv.figure in your experiments.

