### PR TITLE
FIX: surface color

### DIFF
--- a/ipyvolume/pylab.py
+++ b/ipyvolume/pylab.py
@@ -339,7 +339,7 @@ def plot_mesh(x, y, z, color=default_color, wireframe=True, surface=True, wrapx=
         if dim(ar) == 4:
             return [k.reshape(-1, k.shape[-1]) for k in ar]
         else:
-            return ar.reshape(-1, k.shape[-1])
+            return ar.reshape(-1, ar.shape[-1])
 
     if isinstance(color, np.ndarray):
         color = reshape_color(color)
@@ -1090,12 +1090,12 @@ def selector_default(output_widget=None):
                 mask = inside(x, y)
                 scatter.selected = join(scatter.selected, np.where(mask), fig.selection_mode)
     fig.on_selection(lasso)
-    
+
 
 
 def _make_triangles_lines(shape, wrapx=False, wrapy=False):
     """Transform rectangular regular grid into triangles
-    
+
     :param x: {x2d}
     :param y: {y2d}
     :param z: {z2d}
@@ -1103,12 +1103,12 @@ def _make_triangles_lines(shape, wrapx=False, wrapy=False):
     :param bool wrapy: simular for the y coordinate
     :return: triangles and lines used to plot Mesh
     """
-    
+
     nx, ny = shape
 
     mx = nx if wrapx else nx - 1
     my = ny if wrapy else ny - 1
-    
+
     """
     create all pair of indices (i,j) of the rectangular grid
     minus last row if wrapx = False => mx
@@ -1155,18 +1155,17 @@ def _make_triangles_lines(shape, wrapx=False, wrapy=False):
         if (i+1)=nx => (i+1)%nx=0 => close mesh in x direction
         if (j+1)=ny => (j+1)%ny=0 => close mesh in y direction
     """
-    
+
     nt = len(t1[0])
-    
+
     triangles = np.zeros((nt * 2, 3), dtype=np.uint32)
     triangles[0::2, 0], triangles[0::2, 1], triangles[0::2, 2] = t1
     triangles[1::2, 0], triangles[1::2, 1], triangles[1::2, 2] = t2
-    
+
     lines = np.zeros((nt * 4, 2), dtype=np.uint32)
     lines[::4,0], lines[::4,1] = t1[:2]
     lines[1::4,0], lines[1::4,1] = t1[0],t2[2]
     lines[2::4,0], lines[2::4,1] = t2[2:0:-1]
-    lines[3::4,0], lines[3::4,1] = t1[1],t2[1]   
-    
-    return triangles, lines
+    lines[3::4,0], lines[3::4,1] = t1[1],t2[1]
 
+    return triangles, lines


### PR DESCRIPTION
The example below couldn't run.
```python
import os
import numpy as np
import matplotlib.pyplot as plt
from matplotlib import cm
import ipyvolume.pylab as p3

X = np.arange(-5, 5, 0.25*1)
Y = np.arange(-5, 5, 0.25*1)
X, Y = np.meshgrid(X, Y)
R = np.sqrt(X**2 + Y**2)
Z = np.sin(R)
colormap = cm.coolwarm
znorm = Z - Z.min()
znorm /= znorm.ptp()
znorm.min(), znorm.max()
color = colormap(znorm)
p3.figure()
mesh = p3.plot_surface(X, Z, Y, color=color[...,0:3])
p3.show()
```