### PR TITLE
FIX: Update README for dev install

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,4 +81,8 @@ For a development installation (requires npm),
     $ jupyter nbextension install --py --symlink --sys-prefix ipyvolume
     $ jupyter nbextension enable --py --sys-prefix ipyvolume
 
-After changing the javascript, run npm install from the js directory, or `webpack --watch` and work from the examples/dev.ipynb notebook,
+If you have not previously installed widgets, you might also need
+
+    $ jupyter nbextension enable --py --sys-prefix widgetsnbextension
+
+After changing the javascript, run npm install from the js directory, or `webpack --watch` and work from the examples/dev.ipynb notebook.


### PR DESCRIPTION
Following the advice in #93 helped, so I figured it should be added to the README.

Now when running `jupyter notebook` in the `notebooks` directory and running `example.ipynb` I get stuck on the second line with the following warnings:
```
[I 12:32:55.718 NotebookApp] Adapting to protocol v5.1 for kernel 9bd2798f-e1f5-4669-9c5c-e8e10cb28878
[W 12:32:56.202 NotebookApp] 404 GET /static/jupyter-threejs.js?v=20180517123250 (127.0.0.1) 20.48ms referer=http://localhost:8889/notebooks/example.ipynb
[W 12:32:56.273 NotebookApp] 404 GET /static/three.js?v=20180517123250 (127.0.0.1) 0.96ms referer=http://localhost:8889/notebooks/example.ipynb
```
@maartenbreddels any ideas on that one? My `jupyter nbextension list` gives:
```
Known nbextensions:
  config dir: /home/larsoner/.jupyter/nbconfig
    notebook section
      ipyvolume/extension  enabled 
      - Validating: OK
      jupyter-js-widgets/extension  enabled 
      - Validating: OK
```
This is with a `pip --user`-installed Jupyter (`IPython 6.3.1`) on Ubuntu 18.04 system Python 3.6.5. I can try removing and upgrading the stack if you think that would help.