### PR TITLE
Changing webgl configurations so it behaves like OpenGL.

### DIFF
--- a/js/src/figure.js
+++ b/js/src/figure.js
@@ -484,7 +484,7 @@ var FigureView = widgets.DOMWidgetView.extend( {
         this.canvas_overlay_container.appendChild(this.canvas_overlay);
         this.canvas_container.appendChild(this.canvas_overlay_container);
 
-        this.renderer = new THREE.WebGLRenderer({alpha: true, antialias: true});
+        this.renderer = new THREE.WebGLRenderer({alpha: false, antialias: true, premultipliedAlpha: false});
 
         this.canvas_renderer_container = document.createElement("div")
         this.canvas_renderer_container.appendChild(this.renderer.domElement);


### PR DESCRIPTION
I have added a small change to WebGL configurations for working with alpha blending. Previously, I was obtaining undesirable white glow around borders of transparent/opaque regions for some cases and the introduced change makes this transition smooth.

*Without configuration changes, white glowing*
![ipyvolume 16](https://user-images.githubusercontent.com/16047980/41404633-042a5c26-6fc8-11e8-9868-3a59cf03f979.png)


*With changes and without white glowing*
![ipyvolume 19](https://user-images.githubusercontent.com/16047980/41404643-0845126a-6fc8-11e8-9573-9e8585656f6e.png)
