### PR TITLE
Docs: Link to VTK was missing an http

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,7 +9,7 @@ Ipyvolume
 
 IPyvolume is a Python library to visualize 3d volumes and glyphs (e.g. 3d scatter plots), in the Jupyter notebook, with minimal configuration and effort. It is currently pre-1.0, so use at own risk. IPyvolume's *volshow* is to 3d arrays what matplotlib's imshow is to 2d arrays.
 
-Other (more mature but possibly more difficult to use) related packages are `yt <http://yt-project.org/>`_, `VTK <www.vtk.org>`_ and/or `Mayavi <http://docs.enthought.com/mayavi/mayavi/>`_.
+Other (more mature but possibly more difficult to use) related packages are `yt <http://yt-project.org/>`_, `VTK <https://www.vtk.org>`_ and/or `Mayavi <http://docs.enthought.com/mayavi/mayavi/>`_.
 
 
 Feedback and contributions are welcome: `Github <https://github.com/maartenbreddels/ipyvolume>`_, `Email <mailto:maartenbreddels@gmail.com>`_ or `Twitter <https://twitter.com/maartenbreddels>`_.


### PR DESCRIPTION
and thus is appears as "https://ipyvolume.readthedocs.io/en/latest/www.vtk.org" in the rendered documentation which obviously does not work.