### PR TITLE
[WIP] FEATURE: Convenience functions for volume rendering transfer functions

### DIFF
--- a/ipyvolume/transferfunction.py
+++ b/ipyvolume/transferfunction.py
@@ -284,7 +284,7 @@ def load_transfer_functions(include_rgb_linear=True,
             rgb = colors[color_key]
             tf = linear_transfer_function(rgb)
             transfer_functions[color_key] = tf
-            reverse_tf = linear_transfer_function(rgb, reverse_opacity=True)
+            tf_reversed = linear_transfer_function(rgb, reverse_opacity=True)
             transfer_functions[color_key + '_r'] = tf_reversed
     # matplotlib colormaps
     if include_matplotlib:

--- a/ipyvolume/transferfunction.py
+++ b/ipyvolume/transferfunction.py
@@ -288,12 +288,18 @@ def load_transfer_functions(include_rgb_linear=True,
             transfer_functions[color_key + '_r'] = tf_reversed
     # matplotlib colormaps
     if include_matplotlib:
-        matplotlib_colormaps = [m for m in matplotlib.cm.datad if not m.endswith("_r")]
+        matplotlib_colormaps = [m for m in dir(matplotlib.cm) if not m.endswith("_r")]
         for colormap in matplotlib_colormaps:
-            transfer_functions[colormap] = matplotlib_transfer_function(colormap)
+            try:
+                transfer_functions[colormap] = matplotlib_transfer_function(colormap)
+            except ValueError:
+                continue
     # reversed matplotlib colormaps
     if include_matplotlib_reversed:
-        reversed_matplotlib_colormaps = [m for m in matplotlib.cm.datad if m.endswith("_r")]
+        reversed_matplotlib_colormaps = [m for m in dir(matplotlib.cm) if m.endswith("_r")]
         for colormap in reversed_matplotlib_colormaps:
-            transfer_functions[colormap] = matplotlib_transfer_function(colormap)
+            try:
+                transfer_functions[colormap] = matplotlib_transfer_function(colormap)
+            except ValueError:
+                continue
     return transfer_functions


### PR DESCRIPTION
I propose adding convenience functions for volume rendering transfer functions. 

- [x] single color linear ramp transfer functions
- [x] matplotlib colormaps as transfer functions
- [x] function for easy loading of a number of predefined transfer functions
- [ ] function tests - still in progress


Now that it's possible to have multiple volumes displayed in the same figure, we need something like this to increase the useability (and it looks like this has been suggested before):

> I think this can now be done using multivolume rendering. Render each channel as a separate volume, and give them 'ramp' transfer function, having a constant color (say red for the first, green for the second), and opacity increasing from 0 to 1.
https://github.com/maartenbreddels/ipyvolume/issues/81#issuecomment-420551030

I've also seen this issue play out too, since the default choice is very non-standard for my field:
> When I've explained the current system with the 3 RGB gaussians to my
professors, it's always taken a minute for them to understand that red is
low, green is medium, and blue is high. I think having a single linear
color gradient from low to high could eliminate that confusion.
https://github.com/maartenbreddels/ipyvolume/pull/76#issuecomment-336638057

Let me know what your thoughts are, happy to discuss etc.