### PR TITLE
PEP8 imports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,8 @@ before_install:
   - conda info -a
   - conda create -q -n test-environment python=$PYTHON_VERSION numpy scipy runipy
   - source activate test-environment
-  - conda install -c conda-forge pytest pytest-cov bokeh
+  - conda install -c conda-forge pytest pytest-cov bokeh matplotlib scikit-image shapely
+  - pip install PyChromeDevTools
   - pip install coveralls
 
 install:

--- a/ipyvolume/__init__.py
+++ b/ipyvolume/__init__.py
@@ -1,13 +1,57 @@
 from __future__ import absolute_import
-from ._version import __version__
 
+from ._version import __version__
 from . import styles
-from .widgets import *
-from .transferfunction import *
 from . import examples
 from . import datasets
 from . import embed
-from .pylab import *
+from .widgets import (Mesh,
+                      Scatter,
+                      Volume,
+                      Figure,
+                      quickquiver,
+                      quickscatter,
+                      quickvolshow)
+from .transferfunction import (TransferFunction,
+                               TransferFunctionJsBumps,
+                               TransferFunctionWidgetJs3,
+                               TransferFunctionWidget3)
+from .pylab import (current,
+                    clear,
+                    controls_light,
+                    figure,
+                    gcf,
+                    xlim,
+                    ylim,
+                    zlim,
+                    xyzlim,
+                    squarelim,
+                    plot_trisurf,
+                    plot_surface,
+                    plot_wireframe,
+                    plot_mesh,
+                    plot,
+                    scatter,
+                    quiver,
+                    show,
+                    animate_glyphs,
+                    animation_control,
+                    gcc,
+                    transfer_function,
+                    plot_isosurface,
+                    volshow,
+                    save,
+                    movie,
+                    screenshot,
+                    savefig,
+                    xlabel,
+                    ylabel,
+                    zlabel,
+                    xyzlabel,
+                    view,
+                    style,
+                    plot_plane',
+                    selector_default)
 
 def _jupyter_nbextension_paths():
     return [{

--- a/ipyvolume/__init__.py
+++ b/ipyvolume/__init__.py
@@ -50,7 +50,7 @@ from .pylab import (current,
                     xyzlabel,
                     view,
                     style,
-                    plot_plane',
+                    plot_plane,
                     selector_default)
 
 def _jupyter_nbextension_paths():

--- a/ipyvolume/__init__.py
+++ b/ipyvolume/__init__.py
@@ -1,57 +1,57 @@
 from __future__ import absolute_import
 
-from ._version import __version__
-from . import styles
-from . import examples
-from . import datasets
-from . import embed
-from .widgets import (Mesh,
-                      Scatter,
-                      Volume,
-                      Figure,
-                      quickquiver,
-                      quickscatter,
-                      quickvolshow)
-from .transferfunction import (TransferFunction,
-                               TransferFunctionJsBumps,
-                               TransferFunctionWidgetJs3,
-                               TransferFunctionWidget3)
-from .pylab import (current,
-                    clear,
-                    controls_light,
-                    figure,
-                    gcf,
-                    xlim,
-                    ylim,
-                    zlim,
-                    xyzlim,
-                    squarelim,
-                    plot_trisurf,
-                    plot_surface,
-                    plot_wireframe,
-                    plot_mesh,
-                    plot,
-                    scatter,
-                    quiver,
-                    show,
-                    animate_glyphs,
-                    animation_control,
-                    gcc,
-                    transfer_function,
-                    plot_isosurface,
-                    volshow,
-                    save,
-                    movie,
-                    screenshot,
-                    savefig,
-                    xlabel,
-                    ylabel,
-                    zlabel,
-                    xyzlabel,
-                    view,
-                    style,
-                    plot_plane,
-                    selector_default)
+from ipyvolume._version import __version__
+from ipyvolume import styles
+from ipyvolume import examples
+from ipyvolume import datasets
+from ipyvolume import embed
+from ipyvolume.widgets import (Mesh,
+                               Scatter,
+                               Volume,
+                               Figure,
+                               quickquiver,
+                               quickscatter,
+                               quickvolshow)
+from ipyvolume.transferfunction import (TransferFunction,
+                                        TransferFunctionJsBumps,
+                                        TransferFunctionWidgetJs3,
+                                        TransferFunctionWidget3)
+from ipyvolume.pylab import (current,
+                             clear,
+                             controls_light,
+                             figure,
+                             gcf,
+                             xlim,
+                             ylim,
+                             zlim,
+                             xyzlim,
+                             squarelim,
+                             plot_trisurf,
+                             plot_surface,
+                             plot_wireframe,
+                             plot_mesh,
+                             plot,
+                             scatter,
+                             quiver,
+                             show,
+                             animate_glyphs,
+                             animation_control,
+                             gcc,
+                             transfer_function,
+                             plot_isosurface,
+                             volshow,
+                             save,
+                             movie,
+                             screenshot,
+                             savefig,
+                             xlabel,
+                             ylabel,
+                             zlabel,
+                             xyzlabel,
+                             view,
+                             style,
+                             plot_plane,
+                             selector_default)
 
 def _jupyter_nbextension_paths():
     return [{

--- a/ipyvolume/astro.py
+++ b/ipyvolume/astro.py
@@ -2,6 +2,7 @@ import numpy as np
 
 import PIL.Image
 import pythreejs
+import scipy.interpolate
 
 import ipyvolume as ipv
 from ipyvolume.datasets import UrlCached
@@ -19,7 +20,6 @@ def _randomSO3():
 def spherical_galaxy_orbit(orbit_x, orbit_y, orbit_z, N_stars=100, sigma_r=1, orbit_visible=False, orbit_line_interpolate=5, N_star_orbits=10, color=[255, 220, 200], size_star=1, scatter_kwargs={}):
     """Create a fake galaxy around the points orbit_x/y/z with N_stars around it"""
     if orbit_line_interpolate > 1:
-        import scipy.interpolate
         x = np.linspace(0, 1, len(orbit_x))
         x_smooth = np.linspace(0, 1, len(orbit_x)*orbit_line_interpolate)
         kind = 'quadratic'
@@ -75,7 +75,6 @@ def radial_sprite(shape, color):
     return im
 
 def stars(N=1000, radius=100000, thickness=3, seed=42, color=[255, 240, 240]):
-    import ipyvolume as ipv
     rng = np.random.RandomState(seed)
     x, y, z = rng.normal(size=(3, N))
     r = np.sqrt(x**2 + y**2 + z**2)/(radius + thickness * radius * np.random.random(N))

--- a/ipyvolume/astro.py
+++ b/ipyvolume/astro.py
@@ -4,7 +4,7 @@ import PIL.Image
 import pythreejs
 
 import ipyvolume as ipv
-from .datasets import UrlCached
+from ipyvolume.datasets import UrlCached
 
 def _randomSO3():
     """return random rotatation matrix, algo by James Arvo"""
@@ -34,9 +34,9 @@ def spherical_galaxy_orbit(orbit_x, orbit_y, orbit_z, N_stars=100, sigma_r=1, or
     x = np.repeat(orbit_x, N_stars).reshape((-1, N_stars))
     y = np.repeat(orbit_y, N_stars).reshape((-1, N_stars))
     z = np.repeat(orbit_z, N_stars).reshape((-1, N_stars))
-    xr, yr, zr = np.random.normal(0, scale=sigma_r, size=(3, N_stars))# + 
+    xr, yr, zr = np.random.normal(0, scale=sigma_r, size=(3, N_stars))# +
     r = np.sqrt(xr**2 + yr**2 + zr**2)
-    
+
     for i in range(N_stars):
         a = np.linspace(0, 1, x.shape[0]) * 2 * np.pi * N_star_orbits
         xo = r[i] * np.sin(a)
@@ -47,8 +47,8 @@ def spherical_galaxy_orbit(orbit_x, orbit_y, orbit_z, N_stars=100, sigma_r=1, or
         x[:, i] += xo
         y[:, i] += yo
         z[:, i] += zo
-    
-    
+
+
     sprite = ipv.scatter(x, y, z, texture=radial_sprite((64, 64), color), marker='square_2d', size=size_star, **scatter_kwargs)
     with sprite.material.hold_sync():
         sprite.material.blending = pythreejs.BlendingMode.CustomBlending

--- a/ipyvolume/bokeh.py
+++ b/ipyvolume/bokeh.py
@@ -1,9 +1,12 @@
 from __future__ import absolute_import
-from bokeh.models import CustomJS
-from bokeh.plotting import figure
-import ipyvolume
+
 import ipywidgets as widgets
 from traitlets import Unicode
+from bokeh.models import CustomJS
+from bokeh.plotting import figure
+
+import ipyvolume
+
 
 semver_range_frontend = "~" + ipyvolume._version.__version_js__
 

--- a/ipyvolume/datasets.py
+++ b/ipyvolume/datasets.py
@@ -1,20 +1,18 @@
 import os
-import numpy as np
 import bz2
 import gzip
 import platform
-data_dir = os.path.expanduser("~/.ipyvolume/datasets")
-if not os.path.exists(data_dir):
-	os.makedirs(data_dir)
-
 try:
     from urllib import urlretrieve # py2
 except ImportError:
     from urllib.request import urlretrieve # py3
 
+import numpy as np
 
 osname = dict(darwin="osx", linux="linux", windows="windows")[platform.system().lower()]
-
+data_dir = os.path.expanduser("~/.ipyvolume/datasets")
+if not os.path.exists(data_dir):
+	os.makedirs(data_dir)
 
 
 class UrlCached(object):

--- a/ipyvolume/embed.py
+++ b/ipyvolume/embed.py
@@ -2,7 +2,9 @@ import os
 import io
 import zipfile
 import shutil
+
 from ipywidgets import embed as wembed
+
 import ipyvolume
 from ipyvolume.utils import download_to_file, download_to_bytes
 from ipyvolume._version import __version_threejs__
@@ -26,7 +28,7 @@ html_template = u"""<!DOCTYPE html>
 def save_ipyvolumejs(target="", devmode=False,
                      version=ipyvolume._version.__version_js__, version3js=__version_threejs__):
     """ output the ipyvolume javascript to a local file
-    
+
     :type target: str
     :type devmode: bool
     :param devmode: if True get index.js from js/dist directory
@@ -188,7 +190,7 @@ def embed_html(filepath, widgets, makedirs=True, title=u'IPyVolume Widget', all_
 
         cors_attribute = 'crossorigin="anonymous"' if offline_cors else ' '
         snippet = """
-<link href="{rel_script_path}{fname_fontawe}/css/font-awesome.min.css" rel="stylesheet">    
+<link href="{rel_script_path}{fname_fontawe}/css/font-awesome.min.css" rel="stylesheet">
 <script src="{rel_script_path}{fname_require}"{cors} data-main='./{rel_script_path}' ></script>
 <script>
     require.config({{
@@ -200,7 +202,7 @@ def embed_html(filepath, widgets, makedirs=True, title=u'IPyVolume Widget', all_
 </script>
 {subsnippet}
         """.format(rel_script_path=rel_script_path, fname_fontawe=fname_fontawe, fname_require=fname_require,
-                   fname_pyv=os.path.splitext(fname_pyv)[0], 
+                   fname_pyv=os.path.splitext(fname_pyv)[0],
                    subsnippet=subsnippet, cors=cors_attribute)
 
     template_opts['snippet'] = snippet

--- a/ipyvolume/headless.py
+++ b/ipyvolume/headless.py
@@ -6,11 +6,11 @@ Assuming osx, define the following aliases for convenience, and start in headles
      $ chrome --remote-debugging-port=9222 --headless
 
 Make sure you have `PyChromeDevTools` installed::
-    
+
     $ pip install PyChromeDevTools
 
 Now run the following snippet (doesn't have to be from the Jupyter notebook) ::
-    
+
     import ipyvolume as ipv
     ipv.examples.klein_bottle()
     ipv.view(10,30)
@@ -20,10 +20,14 @@ Now run the following snippet (doesn't have to be from the Jupyter notebook) ::
 """
 
 import os
+import time
 import subprocess
 
+import numpy as np
 import PyChromeDevTools
-from . import pylab
+
+from ipyvolume import pylab
+
 
 def _get_browser():
     options = []
@@ -48,9 +52,6 @@ def _screenshot_data(html_filename, timeout_seconds=10, output_widget=None, form
     chrome.Network.enable()
     chrome.Page.enable()
     chrome.Page.navigate(url=html_filename)
-    import time
-    #time.sleep(2)
-    # loadEventFired
     chrome.wait_event("Page.frameStoppedLoading", timeout=60)
     chrome.wait_event("Page.loadEventFired", timeout=60)
     time.sleep(0.5)
@@ -69,7 +70,6 @@ def _screenshot_data(html_filename, timeout_seconds=10, output_widget=None, form
                 raise
 
 def _main():
-    import numpy as np
     print(_get_browser())
     pylab.figure()
     pylab.scatter(*np.random.random((3,100)))

--- a/ipyvolume/moviemaker.py
+++ b/ipyvolume/moviemaker.py
@@ -1,7 +1,7 @@
-import json
-import numpy as np
 import os
+import json
 
+import numpy as np
 import ipywidgets as widgets
 import pythreejs
 import ipywebrtc
@@ -35,13 +35,13 @@ class MovieMaker(object):
         self.times = []
         self.camera_action_box = widgets.HBox()
         self.output = widgets.Output()
-        
+
         self.options_interpolation = [('discrete', 'InterpolateDiscrete'),
                                       ('linear','InterpolateLinear'),
                                       ('smooth','InterpolateSmooth')]
         self.select_interpolation = widgets.Dropdown(options=self.options_interpolation, index=1)
-        
-        
+
+
         self.select_interpolation.observe(lambda x: self.update_keyframes(), 'index')
         self.select_keyframes.observe(lambda x: self.sync_camera(), 'index')
         if positions is None and quaternions is None and times is None:
@@ -59,17 +59,17 @@ class MovieMaker(object):
                               box_control, self.select_keyframes, self.camera_action_box,
                              self.output])
 
-        
+
 #         self.positon_track = pythreejs.VectorKeyframeTrack(name='.position', times=[0], values=[self.camera.position])
 #         self.rotation_track = pythreejs.QuaternionKeyframeTrack(name='.quaternion', times=[0], values=[self.camera.quaternion])
-        
+
     def sync_camera(self):
         with self.output:
             index = self.select_keyframes.index
             if index is not None:
                 self.camera.position = self.positions[index]
                 self.camera.quaternion = self.quaternions[index]
-            
+
     def write_movie(self):
         with self.output:
             filename = self.filename_movie
@@ -108,7 +108,7 @@ class MovieMaker(object):
             self.positions[index] = p
             self.quaternions[index] = q
             self.update_keyframes()
-        
+
     def remove(self):
         index = self.select_keyframes.index
         if index is not None:
@@ -168,8 +168,8 @@ class MovieMaker(object):
     #         self.rotation_track.times = self.times
     #         self.rotation_track.valeus = self.quaternions
 
-        
-        
+
+
     def show(self):
         box_io = widgets.HBox([self.button_save, self.button_load])
         box_control = widgets.HBox([self.button_add, self.button_replace, self.button_remove])

--- a/ipyvolume/pylab.py
+++ b/ipyvolume/pylab.py
@@ -23,6 +23,16 @@ except:
 import base64
 
 
+__all__ = ['current', 'clear', 'controls_light', 'figure', 'gcf',
+          'xlim', 'ylim', 'zlim', 'xyzlim', 'squarelim',
+          'plot_trisurf', 'plot_surface', 'plot_wireframe', 'plot_mesh',
+          'plot', 'scatter', 'quiver', 'show', 'animate_glyphs',
+          'animation_control', 'gcc', 'transfer_function', 'plot_isosurface',
+          'volshow', 'save', 'movie', 'screenshot', 'savefig',
+          'xlabel', 'ylabel', 'zlabel', 'xyzlabel', 'view', 'style',
+          'plot_plane', 'selector_default']
+
+
 def _docsubst(f):
     """Perform docstring substitutions"""
     f.__doc__ = f.__doc__.format(**_doc_snippets)
@@ -650,7 +660,7 @@ def volshow(data, lighting=False, data_min=None, data_max=None,
 
     :param data: 3d numpy array
     :param origin: origin of the volume data, this is to match meshes which have a different origin
-    :param domain_size: domain size is the size of the volume 
+    :param domain_size: domain size is the size of the volume
     :param bool lighting: use lighting or not, if set to false, lighting parameters will be overriden
     :param float data_min: minimum value to consider for data, if None, computed using np.nanmin
     :param float data_max: maximum value to consider for data, if None, computed using np.nanmax
@@ -704,7 +714,7 @@ def volshow(data, lighting=False, data_min=None, data_max=None,
     vol._listen_to(fig)
 
     if controls:
-        widget_opacity_scale = ipywidgets.FloatLogSlider(base=10, min=-2, max=2, 
+        widget_opacity_scale = ipywidgets.FloatLogSlider(base=10, min=-2, max=2,
                                                      description="opacity")
         widget_brightness = ipywidgets.FloatLogSlider(base=10, min=-1, max=1,
                                                      description="brightness")

--- a/ipyvolume/pylab.py
+++ b/ipyvolume/pylab.py
@@ -15,6 +15,7 @@ __all__ = ['current', 'clear', 'controls_light', 'figure', 'gcf',
 import os
 import time
 import warnings
+import tempfile
 import uuid
 import base64
 try:
@@ -22,8 +23,12 @@ try:
 except:
     from cStringIO import StringIO
 
+import six
 import numpy as np
 import PIL.Image
+import matplotlib.style
+import shapely.geometry
+from skimage import measure
 import ipywidgets
 import traitlets
 import IPython
@@ -33,6 +38,7 @@ import ipyvolume as ipv
 import ipyvolume.embed
 from ipyvolume import utils
 from ipyvolume import examples
+from ipyvolume import headless
 
 
 _last_figure = None
@@ -601,7 +607,6 @@ def plot_isosurface(data, level=None, color=default_color, wireframe=True, surfa
     :param extent: list of [[xmin, xmax], [ymin, ymax], [zmin, zmax]] values that define the bounding box of the mesh, otherwise the viewport is used
     :return: :any:`Mesh`
     """
-    from skimage import measure
     if level is None:
         level = np.median(data)
     if hasattr(measure, 'marching_cubes_lewiner'):
@@ -796,7 +801,6 @@ def movie(f="movie.mp4", function=_change_azimuth_angle, fps=30, frames=30, endp
     :return: the temp dir where the frames are stored
     """
     movie_filename = f
-    import tempfile
     tempdir = tempfile.mkdtemp()
     output = ipywidgets.Output()
     display(output)
@@ -828,8 +832,6 @@ def _screenshot_data(timeout_seconds=10, output_widget=None, format="png", width
     else:
         assert isinstance(fig, ipv.Figure)
     if headless:
-        from . import headless
-        import tempfile
         tempdir = tempfile.mkdtemp()
         tempfile = os.path.join(tempdir, 'headless.html')
         save(tempfile, offline=False, scripts_path=tempdir, devmode=devmode)
@@ -994,7 +996,6 @@ class style:
         :param style: matplotlib style name, or dict with values, or a sequence of these, where the last value overrides previous
         :return:
         """
-        import six
         def valid(value):  # checks if json'able
             return isinstance(value, six.string_types)
 
@@ -1035,7 +1036,6 @@ class style:
                 else:
                     # lets see if we can copy matplotlib's style
                     # we assume now it's a matplotlib style, get all properties that we understand
-                    import matplotlib.style
                     cleaned_style = {key: value for key, value in dict(matplotlib.style.library[style]).items() if
                                      valid(value)}
                     style = translate(cleaned_style)
@@ -1157,7 +1157,6 @@ def selector_default(output_widget=None):
     def lasso(data, other=None, fig=fig):
         with output_widget:
             if data['device'] and data['type'] == 'lasso':
-                import shapely.geometry
                 region = shapely.geometry.Polygon(data['device'])
                 @np.vectorize
                 def inside(x, y):

--- a/ipyvolume/pylab.py
+++ b/ipyvolume/pylab.py
@@ -1,27 +1,7 @@
+"""The pylab module of ipvyolume."""
+
 from __future__ import absolute_import
 from __future__ import division
-_last_figure = None
-import ipywidgets
-from IPython.display import display
-import IPython
-import ipyvolume as ipv
-import ipyvolume.embed
-import os
-import numpy as np
-from . import utils
-import time
-from . import examples
-import warnings
-import PIL.Image
-import traitlets
-import uuid
-
-try:
-    from io import BytesIO as StringIO
-except:
-    from cStringIO import StringIO
-import base64
-
 
 __all__ = ['current', 'clear', 'controls_light', 'figure', 'gcf',
           'xlim', 'ylim', 'zlim', 'xyzlim', 'squarelim',
@@ -31,6 +11,31 @@ __all__ = ['current', 'clear', 'controls_light', 'figure', 'gcf',
           'volshow', 'save', 'movie', 'screenshot', 'savefig',
           'xlabel', 'ylabel', 'zlabel', 'xyzlabel', 'view', 'style',
           'plot_plane', 'selector_default']
+
+import os
+import time
+import warnings
+import uuid
+import base64
+try:
+    from io import BytesIO as StringIO
+except:
+    from cStringIO import StringIO
+
+import numpy as np
+import PIL.Image
+import ipywidgets
+import traitlets
+import IPython
+from IPython.display import display
+
+import ipyvolume as ipv
+import ipyvolume.embed
+from ipyvolume import utils
+from ipyvolume import examples
+
+
+_last_figure = None
 
 
 def _docsubst(f):

--- a/ipyvolume/serialize.py
+++ b/ipyvolume/serialize.py
@@ -1,23 +1,27 @@
 from __future__ import division
+
+import sys
 import logging
+import warnings
 import math
-
-from ipython_genutils.py3compat import string_types, PY3
-import ipyvolume as ipv
-from . import utils
-import ipywidgets
-import ipywebrtc
-import numpy as np
-import PIL.Image
-
+from base64 import b64encode
 try:
 	from io import BytesIO as StringIO # python3
 except:
 	from StringIO import StringIO # python2
-from base64 import b64encode
-import warnings
+
+import numpy as np
+import PIL.Image
+import ipywidgets
+import ipywebrtc
+from ipython_genutils.py3compat import string_types, PY3
+
+import ipyvolume as ipv
+from ipyvolume import utils
+
 
 logger = logging.getLogger("ipyvolume")
+
 
 def image_to_url(image, widget):
     if image is None:
@@ -59,7 +63,7 @@ max_texture_width = 2048*8  # this will nicely fit 512**3 textures
 min_texture_width = 256
 
 def _compute_tile_size(shape):
-	# TODO: we need to be a bit smarter here, for large grids we need to 
+	# TODO: we need to be a bit smarter here, for large grids we need to
 	slices = shape[0]
 	approx_rows = int(round(math.sqrt(slices)))
 	image_width = max(min_texture_width, min(max_texture_width, utils.next_power_of_2(approx_rows * shape[1])))
@@ -80,7 +84,6 @@ def _cube_to_tiles(grid, vmin, vmax):
 	with np.errstate(divide='ignore'):
 		gradient = gradient / np.sqrt(gradient[0]**2 + gradient[1]**2 + gradient[2]**2)
 	# intensity_normalized = (np.log(self.data3d + 1.) - np.log(mi)) / (np.log(ma) - np.log(mi));
-	import PIL.Image
 	for y2d in range(rows):
 		for x2d in range(columns):
 			zindex = x2d + y2d * columns
@@ -117,7 +120,7 @@ def tile_volume(vol, tex_size, tile_shape, vol_size):
 	            break
 	        slice_data = vol[z]
 	        xoffset = tileX*vol_size[0]
-	        yoffset = tileY*vol_size[1]	
+	        yoffset = tileY*vol_size[1]
 	        tex[yoffset:yoffset+vol_size[1],xoffset:xoffset+vol_size[0]] = slice_data
 	# debug image saving
 	# scipy.misc.toimage(tex, cmin=tex.min(), cmax=tex.max()).save('outfile.png')
@@ -146,20 +149,19 @@ def volume_to_json_volume_tiled(vol, obj=None):
 	#print "vol_shape: {}, a: {}, tile_shape: {}, tex_size: {}".format(vol_shape,a, tile_shape, tex_size)
 
 	if vol.ndim == 4: #time series
-		return {"volume_data_tiled":[tile_volume(vol[t], tex_size, tile_shape, vol_shape) for t in range(vol.shape[0])], 
+		return {"volume_data_tiled":[tile_volume(vol[t], tex_size, tile_shape, vol_shape) for t in range(vol.shape[0])],
 				"shape":vol_shape,
 				"tile_shape": tile_shape,
 				"vol_tex_size": tex_size}
 	else:
-		return {"volume_data_tiled":[tile_volume(vol, tex_size, tile_shape, vol_shape)], 
-				"shape":vol_shape, 
+		return {"volume_data_tiled":[tile_volume(vol, tex_size, tile_shape, vol_shape)],
+				"shape":vol_shape,
 				"tile_shape": tile_shape,
 				"vol_tex_size": tex_size}
 
 	return None
 
 def rgba_to_png(rgba, file):
-	import PIL.Image
 	if len(rgba.shape) != 3 or rgba.shape[-1] != 4:
 		return None
 		logger.error("only 3d arrays with the last dimension equal to 4 (rgba images) are supported")
@@ -344,7 +346,6 @@ texture_serialization = dict(to_json=texture_to_json, from_json=None)
 ndarray_serialization = dict(to_json=array_to_binary, from_json=binary_to_array)
 
 if __name__ == "__main__":
-    import sys
     grid = np.load(sys.argv[1]).items()[0][1]
     with open(sys.argv[2], "wb") as f:
 	    cube_to_png(np.log10(grid+1), f)

--- a/ipyvolume/styles.py
+++ b/ipyvolume/styles.py
@@ -21,8 +21,13 @@ Run:
 python -m ipyvolume.style
 to update the json style (needed for the js side)
 """
-from . import utils
+
+import os
+import json
 import copy
+
+from ipyvolume import utils
+
 
 styles = {}
 _defaults = {
@@ -128,15 +133,12 @@ nobox = create("nobox", {
 })
 
 if __name__ == "__main__":
-    import os
     source = __file__
     dest = os.path.join(os.path.dirname(source), "../js/data/style.json")
     print(source, dest)
     need_update = (not os.path.exists(dest)) or (os.path.getmtime(source) > os.path.getmtime(dest))
     if need_update:
-        import json
         print(styles)
         with open(dest, "w") as f:
             json.dump(styles, f, indent=2)
         print("wrote json")
-

--- a/ipyvolume/test_all.py
+++ b/ipyvolume/test_all.py
@@ -1,4 +1,13 @@
 from __future__ import absolute_import
+
+import os
+import shutil
+import json
+import contextlib
+
+import numpy as np
+import pytest
+
 import ipyvolume
 import ipyvolume.pylab as p3
 import ipyvolume as ipv
@@ -6,12 +15,6 @@ import ipyvolume.examples
 import ipyvolume.datasets
 import ipyvolume.utils
 import ipyvolume.serialize
-import numpy as np
-import os
-import shutil
-import json
-import pytest
-import contextlib
 
 
 @contextlib.contextmanager
@@ -37,7 +40,7 @@ def test_serialize():
 
     value = np.asarray(5)
     assert ipyvolume.serialize.array_sequence_to_binary_or_json(value) == 5
-    
+
     value = np.asarray(5)
     assert ipyvolume.serialize.array_sequence_to_binary_or_json(value) == 5
 
@@ -93,14 +96,14 @@ def test_figure():
     f5 = p3.gcf()
     p3.clear()
     f6 = p3.gcf()
-    
+
     assert f1 != f2
     assert f2 != f3
     assert f3 != f4
     assert f2 == f2
     assert f4 == f5
     assert f5 != f6
-    
+
     f7 = p3.figure('f7')
     f8 = p3.figure()
     f9 = p3.figure('f7')
@@ -108,14 +111,14 @@ def test_figure():
     f11 = p3.gcf()
     f12 = p3.current.figure
     f13 = p3.figure('f7')
-    f14 = p3.current.figures['f7'] 
-   
+    f14 = p3.current.figures['f7']
+
     assert f7 == f9
     assert f8 == f10
     assert f10 == f11
     assert f11 == f12
     assert f13 == f14
-    
+
     for controls in [True, False]:
         for debug in [True, False]:
             for controls_light in [True, False]:

--- a/ipyvolume/transferfunction.py
+++ b/ipyvolume/transferfunction.py
@@ -6,7 +6,8 @@ __all__ = ['TransferFunction', 'TransferFunctionJsBumps',
            'TransferFunctionWidgetJs3', 'TransferFunctionWidget3']
 
 import numpy as np
-import ipywidgets as widgets
+import ipywidgets
+import ipywidgets as widgets  # we should not have ipywidgets under two names
 import traitlets
 from traitlets import Unicode, validate
 from traittypes import Array
@@ -56,7 +57,6 @@ class TransferFunctionJsBumps(TransferFunction):
 
 
 	def control(self, max_opacity=0.2):
-		import ipywidgets
 		return ipywidgets.VBox()
 		l1 = ipywidgets.FloatSlider(min=0, max=1, step=0.001, value=self.level1)
 		l2 = ipywidgets.FloatSlider(min=0, max=1, step=0.001, value=self.level2)
@@ -91,7 +91,6 @@ class TransferFunctionWidgetJs3(TransferFunction):
 
 
 	def control(self, max_opacity=0.2):
-		import ipywidgets
 		l1 = ipywidgets.FloatSlider(min=0, max=1, step=0.001, value=self.level1)
 		l2 = ipywidgets.FloatSlider(min=0, max=1, step=0.001, value=self.level2)
 		l3 = ipywidgets.FloatSlider(min=0, max=1, step=0.001, value=self.level3)
@@ -155,7 +154,6 @@ class TransferFunctionWidget3(TransferFunction):
 		#self._notify_trait("rgba", old_value, self.rgba)
 
 	def control(self, max_opacity=0.2):
-		import ipywidgets
 		l1 = ipywidgets.FloatSlider(min=0, max=1, value=self.level1)
 		l2 = ipywidgets.FloatSlider(min=0, max=1, value=self.level2)
 		l3 = ipywidgets.FloatSlider(min=0, max=1, value=self.level3)

--- a/ipyvolume/transferfunction.py
+++ b/ipyvolume/transferfunction.py
@@ -1,23 +1,24 @@
+"""The transferfunction module of ipvyolume."""
+
 from __future__ import absolute_import
-import ipywidgets as widgets
-from traitlets import Unicode, validate
-from traittypes import Array
-import traitlets
-import numpy as np
-from . import serialize
-from .serialize import array_rgba_png_serialization, array_serialization
-N = 1024
-x = np.linspace(0, 1, N, endpoint=True)
-
-import ipyvolume._version
-
 
 __all__ = ['TransferFunction', 'TransferFunctionJsBumps',
            'TransferFunctionWidgetJs3', 'TransferFunctionWidget3']
 
+import numpy as np
+import ipywidgets as widgets
+import traitlets
+from traitlets import Unicode, validate
+from traittypes import Array
 
+import ipyvolume._version
+from ipyvolume import serialize
+from ipyvolume.serialize import array_rgba_png_serialization, array_serialization
+
+
+N = 1024
+x = np.linspace(0, 1, N, endpoint=True)
 semver_range_frontend = "~" + ipyvolume._version.__version_js__
-
 
 if 0:
 	def array_from_json(value, obj=None):

--- a/ipyvolume/transferfunction.py
+++ b/ipyvolume/transferfunction.py
@@ -10,6 +10,12 @@ N = 1024
 x = np.linspace(0, 1, N, endpoint=True)
 
 import ipyvolume._version
+
+
+__all__ = ['TransferFunction', 'TransferFunctionJsBumps',
+           'TransferFunctionWidgetJs3', 'TransferFunctionWidget3']
+
+
 semver_range_frontend = "~" + ipyvolume._version.__version_js__
 
 

--- a/ipyvolume/utils.py
+++ b/ipyvolume/utils.py
@@ -1,12 +1,15 @@
 from __future__ import print_function
-import collections
-import requests
-import io
+
 import os
-import numpy as np
+import io
+import time
 import functools
 import collections
-import time
+
+import numpy as np
+import requests
+import IPython
+import zmq
 
 
 # https://stackoverflow.com/questions/14267555/find-the-smallest-power-of-2-greater-than-n-in-python
@@ -251,8 +254,6 @@ def grid_slice(amin, amax, shape, bmin, bmax):
     return (imin, imax), (amin + nmin * width, amin + nmax * width)
 
 def get_ioloop():
-    import IPython
-    import zmq
     ipython = IPython.get_ipython()
     if ipython and hasattr(ipython, 'kernel'):
         return zmq.eventloop.ioloop.IOLoop.instance()

--- a/ipyvolume/widgets.py
+++ b/ipyvolume/widgets.py
@@ -1,30 +1,41 @@
+"""The widgets module of ipvyolume."""
+
 from __future__ import absolute_import
-import ipywidgets as widgets
-import ipywidgets
-from traittypes import Array
-from ipyvolume.traittypes import Image
-from traitlets import Unicode, Integer
-import traitlets
-import logging
-import numpy as np
-from .serialize import array_cube_tile_serialization, array_serialization, array_sequence_serialization,\
-    color_serialization, image_serialization, texture_serialization
-from .transferfunction import *
-from .utils import debounced, grid_slice, reduce_size
-import warnings
-import ipyvolume
-import ipywebrtc
-import pythreejs
-
-logger = logging.getLogger("ipyvolume")
-
-_last_volume_renderer = None
-import ipyvolume._version
-semver_range_frontend = "~" + ipyvolume._version.__version_js__
-
 
 __all__ = ['Mesh', 'Scatter', 'Volume', 'Figure',
            'quickquiver', 'quickscatter', 'quickvolshow']
+
+import logging
+import warnings
+
+import numpy as np
+import ipywidgets
+import ipywidgets as widgets  # we should not have ipywidgets under two names
+import ipywebrtc
+import pythreejs
+import traitlets
+from traitlets import Unicode, Integer
+from traittypes import Array
+
+import ipyvolume
+import ipyvolume._version
+from ipyvolume.traittypes import Image
+from ipyvolume.serialize import (array_cube_tile_serialization,
+                        array_serialization,
+                        array_sequence_serialization,
+                        color_serialization,
+                        image_serialization,
+                        texture_serialization)
+from ipyvolume.transferfunction import (TransferFunction,
+                                        TransferFunctionJsBumps,
+                                        TransferFunctionWidgetJs3,
+                                        TransferFunctionWidget3)
+from ipyvolume.utils import debounced, grid_slice, reduce_size
+
+
+_last_volume_renderer = None
+logger = logging.getLogger("ipyvolume")
+semver_range_frontend = "~" + ipyvolume._version.__version_js__
 
 
 @widgets.register

--- a/ipyvolume/widgets.py
+++ b/ipyvolume/widgets.py
@@ -18,6 +18,7 @@ from traitlets import Unicode, Integer
 from traittypes import Array
 
 import ipyvolume
+import ipyvolume as ipv  # we should not have ipyvolume under two names either
 import ipyvolume._version
 from ipyvolume.traittypes import Image
 from ipyvolume.serialize import (array_cube_tile_serialization,
@@ -181,7 +182,6 @@ class Volume(widgets.Widget):
             self.data = self.data_original
             self.extent = self.extent_original
             return
-        import ipyvolume as ipv
         current_figure = ipv.gcf()
         xlim = current_figure.xlim
         ylim = current_figure.ylim
@@ -293,13 +293,10 @@ class Figure(ipywebrtc.MediaStream):
         >>> assert ipv.gcf() is f2
         """
 
-
-        import ipyvolume as ipv
         self._previous_figure = ipv.gcf()
         ipv.figure(self)
 
     def __exit__(self, type, value, traceback):
-        import ipyvolume as ipv
         ipv.figure(self._previous_figure)
         del self._previous_figure
 
@@ -334,13 +331,11 @@ def volshow(*args, **kwargs):
     return quickvolshow(*args, **kwargs)
 
 def quickquiver(x, y, z, u, v, w, **kwargs):
-    import ipyvolume as ipv
     ipv.figure()
     ipv.quiver(x, y, z, u, v, w, **kwargs)
     return ipv.gcc()
 
 def quickscatter(x, y, z, **kwargs):
-    import ipyvolume as ipv
     ipv.figure()
     ipv.scatter(x, y, z, **kwargs)
     return ipv.gcc()
@@ -364,7 +359,6 @@ def quickvolshow(data, lighting=False, data_min=None, data_max=None,  max_shape=
     :return:
 
     """
-    import ipyvolume as ipv
     ipv.figure()
     ipv.volshow(data, lighting=lighting, data_min=data_min, data_max=data_max, max_shape=max_shape,
         level=level, opacity=opacity, level_width=level_width, extent=extent,  memorder=memorder, **kwargs)

--- a/ipyvolume/widgets.py
+++ b/ipyvolume/widgets.py
@@ -22,6 +22,11 @@ _last_volume_renderer = None
 import ipyvolume._version
 semver_range_frontend = "~" + ipyvolume._version.__version_js__
 
+
+__all__ = ['Mesh', 'Scatter', 'Volume', 'Figure',
+           'quickquiver', 'quickscatter', 'quickvolshow']
+
+
 @widgets.register
 class Mesh(widgets.Widget):
     _view_name = Unicode('MeshView').tag(sync=True)


### PR DESCRIPTION
I've done some tidying to bring the code more into line with PEP8, in particular the recommendations on imports.

## What this PR includes:
- [x] ordered imports according to the PEP8 guidelines (i.e. standard library imports first, third-party libraries second, ipyvolume imports last)
- [x] replaced wildcard imports with explicit imports 
- [x] moved all import statements to the top of the file

I haven't touched very much of examples.py or test_all.py, not sure if they need slightly special handling.