### PR TITLE
README animation gif example is now up to date

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,16 @@ Documentation is generated at readthedocs: [![Documentation](https://readthedocs
 # Screencast demos
 
 ## Animation
+```python
+import ipyvolume as ipv
+ds_stream = ipv.datasets.animated_stream.fetch()
 
+fig = ipv.figure()
+ipv.style.use('dark')
+q = ipv.quiver(*ds_stream.data, size=6)
+ipv.animation_control(q, interval=200)
+ipv.show()
+```
 ![screencast](https://cloud.githubusercontent.com/assets/1765949/23901444/8d4f26f8-08bd-11e7-81e6-cedad0a8471c.gif)
 
 (see more at [the documentation](https://ipyvolume.readthedocs.io/en/latest/animation.html))

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ q = ipv.quiver(*ds_stream.data, size=6)
 ipv.animation_control(q, interval=200)
 ipv.show()
 ```
-![screencast](https://cloud.githubusercontent.com/assets/1765949/23901444/8d4f26f8-08bd-11e7-81e6-cedad0a8471c.gif)
+![Animation of ds_stream.data](misc/screencast_animation.gif)
 
 (see more at [the documentation](https://ipyvolume.readthedocs.io/en/latest/animation.html))
 


### PR DESCRIPTION
I noticed the animation screencast on the README page had some deprecated code visible in the gif, so I've updated it.

Now the README has:
- [x] A complete code snippet you can copy-paste and run immediately
- [x] A cropped version of the gif, that doesn't show the notebook cell with the old & deprecated `animate_glpyhs` command, which has been superseded by `animation_control`

Here's a static screenshot of the revised section:

<img width="524" alt="screen shot 2018-09-26 at 9 29 07 pm" src="https://user-images.githubusercontent.com/30920819/46077171-484bfd80-c1d3-11e8-8141-77ef89958e85.png">
