### PR TITLE
Fix doubled command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The Jupyter lab extension is not enabled by default (yet).
 
 ```
 $ conda install -c conda-forge nodejs  # or some other way to have a recent node
-$ jupyter labextension install jupyter labextension install @jupyter-widgets/jupyterlab-manager
+$ jupyter labextension install @jupyter-widgets/jupyterlab-manager
 $ jupyter labextension install ipyvolume
 $ jupyter labextension install jupyter-threejs
 


### PR DESCRIPTION
In the instructions of the jupyter-lab setup is a command doubled.