### PR TITLE
Removes traitlets DeprecationWarning

### DIFF
--- a/ipyvolume/transferfunction.py
+++ b/ipyvolume/transferfunction.py
@@ -51,9 +51,9 @@ class TransferFunction(widgets.DOMWidget):
 class TransferFunctionJsBumps(TransferFunction):
 	_model_name = Unicode('TransferFunctionJsBumpsModel').tag(sync=True)
 	_model_module = Unicode('ipyvolume').tag(sync=True)
-	levels = traitlets.List(traitlets.CFloat, default_value=[0.1, 0.5, 0.8]).tag(sync=True)
-	opacities = traitlets.List(traitlets.CFloat, default_value=[0.01, 0.05, 0.1]).tag(sync=True)
-	widths = traitlets.List(traitlets.CFloat, default_value=[0.1, 0.1, 0.1]).tag(sync=True)
+	levels = traitlets.List(traitlets.CFloat(), default_value=[0.1, 0.5, 0.8]).tag(sync=True)
+	opacities = traitlets.List(traitlets.CFloat(), default_value=[0.01, 0.05, 0.1]).tag(sync=True)
+	widths = traitlets.List(traitlets.CFloat(), default_value=[0.1, 0.1, 0.1]).tag(sync=True)
 
 
 	def control(self, max_opacity=0.2):

--- a/ipyvolume/widgets.py
+++ b/ipyvolume/widgets.py
@@ -226,7 +226,7 @@ class Figure(ipywebrtc.MediaStream):
 
     camera_control = traitlets.Unicode(default_value='trackball').tag(sync=True)
     camera_fov = traitlets.CFloat(45,min=0.1,max=179.9).tag(sync=True)
-    camera_center = traitlets.List(traitlets.CFloat, default_value=[0, 0, 0]).tag(sync=True)
+    camera_center = traitlets.List(traitlets.CFloat(), default_value=[0, 0, 0]).tag(sync=True)
     #Tuple(traitlets.CFloat(0), traitlets.CFloat(0), traitlets.CFloat(0)).tag(sync=True)
 
     camera = traitlets.Instance(pythreejs.Camera, allow_none=True, help='A :any:`pythreejs.Camera` instance to control the camera')\
@@ -253,12 +253,12 @@ class Figure(ipywebrtc.MediaStream):
 
     show = traitlets.Unicode("Volume").tag(sync=True) # for debugging
 
-    xlim = traitlets.List(traitlets.CFloat, default_value=[0, 1], minlen=2, maxlen=2).tag(sync=True)
-    ylim = traitlets.List(traitlets.CFloat, default_value=[0, 1], minlen=2, maxlen=2).tag(sync=True)
-    zlim = traitlets.List(traitlets.CFloat, default_value=[0, 1], minlen=2, maxlen=2).tag(sync=True)
+    xlim = traitlets.List(traitlets.CFloat(), default_value=[0, 1], minlen=2, maxlen=2).tag(sync=True)
+    ylim = traitlets.List(traitlets.CFloat(), default_value=[0, 1], minlen=2, maxlen=2).tag(sync=True)
+    zlim = traitlets.List(traitlets.CFloat(), default_value=[0, 1], minlen=2, maxlen=2).tag(sync=True)
 
-    matrix_projection = traitlets.List(traitlets.CFloat, default_value=[0] * 16, allow_none=True, minlen=16, maxlen=16).tag(sync=True)
-    matrix_world = traitlets.List(traitlets.CFloat, default_value=[0] * 16, allow_none=True, minlen=16, maxlen=16).tag(sync=True)
+    matrix_projection = traitlets.List(traitlets.CFloat(), default_value=[0] * 16, allow_none=True, minlen=16, maxlen=16).tag(sync=True)
+    matrix_world = traitlets.List(traitlets.CFloat(), default_value=[0] * 16, allow_none=True, minlen=16, maxlen=16).tag(sync=True)
 
     xlabel = traitlets.Unicode("x").tag(sync=True)
     ylabel = traitlets.Unicode("y").tag(sync=True)


### PR DESCRIPTION
Traitlets raises a DeprecationWarning about the way to pass datatypes as arguments:

```python-traceback
home/travis/miniconda/envs/tyssue/lib/python3.7/site-packages/ipyvolume/transferfunction.py:46
  /home/travis/miniconda/envs/tyssue/lib/python3.7/site-packages/ipyvolume/transferfunction.py:46: DeprecationWarning: Traits should be given as instances, not types (for example, `Int()`, not `Int`). Passing types is deprecated in traitlets 4.1.
    levels = traitlets.List(traitlets.CFloat, default_value=[0.1, 0.5, 0.8]).tag(sync=True)
```

This PR fixes the related code.
 