### PR TITLE
Update conda installation instructions

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -115,7 +115,6 @@ For conda/anaconda, use:
 ::
 
     conda install -c conda-forge ipyvolume
-    pip install ipywidgets~=6.0.0b5 --user
 
 
 About


### PR DESCRIPTION
If I'm not wrong, installing a custom version of `ipywidgets` is not required anymore.