### PR TITLE
Include license in wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,6 @@ universal=1
 max-line-length = 130
 # once we become more mature, we may want to be more strict
 ignore = D100, D101, D102, D103, D104, D105, D107, E203, E722
+
+[metadata]
+license_file = LICENSE


### PR DESCRIPTION
The MIT license requires all copies of the software include the license.