### PR TITLE
Enable panning in "orbit" mode

### DIFF
--- a/js/src/figure.js
+++ b/js/src/figure.js
@@ -395,13 +395,6 @@ var FigureView = widgets.DOMWidgetView.extend({
         if (this.model.get('camera')) {
             this.camera = this.model.get('camera').obj
             this.model.get('camera').on('change', () => {
-                // the threejs' lookAt ignore the quaternion, and uses the up vector
-                // we manually set it ourselve
-                var up = new THREE.Vector3(0, 1, 0);
-                up.applyQuaternion(this.camera.quaternion);
-                this.camera.up = up;
-                this.camera.lookAt(0, 0, 0);
-                // TODO: shouldn't we do the same with the orbit control?
                 this.control_trackball.position0 = this.camera.position.clone();
                 this.control_trackball.up0 = this.camera.up.clone();
                 // TODO: if we implement figure.look_at, we should update control's target as well
@@ -634,7 +627,10 @@ var FigureView = widgets.DOMWidgetView.extend({
         this.control_orbit = new THREE.OrbitControls(this.camera, this.renderer.domElement);
         this.control_trackball.dynamicDampingFactor = 1.
         this.control_trackball.noPan = true;
-        this.control_orbit.enablePan = false;
+        // All widgets on the page would receive those keypresses all the time:
+        this.control_orbit.enableKeys = false;
+        this.control_orbit.panSpeed = 1.0;
+        this.control_orbit.screenSpacePanning = true;
         this.control_orbit.dampingFactor = 1.
         this.update_mouse_mode()
 
@@ -1462,9 +1458,6 @@ var FigureView = widgets.DOMWidgetView.extend({
     _real_update: function() {
         this.control_trackball.handleResize()
         this._update_requested = false
-        // since the threejs animation system can update the camera,
-        // make sure we keep looking at the center
-        this.camera.lookAt(0, 0, 0)
 
         this.renderer.setClearColor(this.get_style_color('background-color'))
         this.x_axis.visible = this.get_style('axes.x.visible axes.visible')


### PR DESCRIPTION
To select "orbit" mode, click the "up arrow" symbol in the widget.

Panning works with the right mouse button.

Panning with the arrow keys on the keyboard is still disabled (which I think was the reason to disable panning in the first place).

I had to remove some `lookAt()` calls, but I don't see any change in the behavior of the "trackball" mode because of this. Did I miss something?

This is a (less intrusive) subset of #272.

