### PR TITLE
import Mapping from abc

### DIFF
--- a/ipyvolume/utils.py
+++ b/ipyvolume/utils.py
@@ -20,7 +20,7 @@ def next_power_of_2(x):
 # original from http://stackoverflow.com/questions/3232943/update-value-of-a-nested-dictionary-of-varying-depth
 def dict_deep_update(d, u):
     for k, v in u.items():
-        if isinstance(v, collections.Mapping):
+        if isinstance(v, collections.abc.Mapping):
             r = dict_deep_update(d.get(k, {}), v)
             d[k] = r
         else:


### PR DESCRIPTION
Importing and ABC directly from collections is deprecated and raises a warning in my tests.
This should fix the warning