### PR TITLE
Fix ipyvolume for JupyterLab 2.1.0

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -64,7 +64,8 @@
   },
   "dependencies": {
     "@jupyter-widgets/base": "^1 || ^2 || ^3 || ^4",
-    "@jupyter-widgets/controls": "^1.4.2",
+    "@jupyter-widgets/controls": "^1 || ^2",
+    "@jupyterlab/application": "^2.1.0",
     "css-loader": "^0.28.4",
     "d3": "^5.7.0",
     "gl-matrix": "^2.0.0",

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -14,7 +14,3 @@ export * from "./tf";
 export * from "./scatter";
 export * from "./volume";
 export * from "./mesh";
-export * from "./utils";
-export * from "./selectors";
-export * from "./values";
-export {semver_range as version} from "./utils";

--- a/js/src/labplugin.ts
+++ b/js/src/labplugin.ts
@@ -1,13 +1,15 @@
 import * as base from "@jupyter-widgets/base";
 import * as jupyter_volume from "./index";
+import {semver_range} from "./utils";
+import {JupyterFrontEnd, JupyterFrontEndPlugin} from '@jupyterlab/application';
 
-const plugin = {
+const plugin: JupyterFrontEndPlugin<void> = {
   id: "ipyvolume",
   requires: [base.IJupyterWidgetRegistry],
-  activate(app, widgets) {
+  activate(app: JupyterFrontEnd, widgets: base.IJupyterWidgetRegistry) {
       widgets.registerWidget({
           name: "ipyvolume",
-          version: jupyter_volume.version,
+          version: semver_range,
           exports: jupyter_volume,
       });
   },

--- a/js/src/utils.ts
+++ b/js/src/utils.ts
@@ -2,7 +2,7 @@ import isTypedArray from "is-typedarray";
 
 // same strategy as: ipywidgets/jupyter-js-widgets/src/widget_core.ts, except we use ~
 // so that N.M.x is allowed (we don't care about x, but we assume 0.2.x is not compatible with 0.3.x
-export const semver_range = "~";
+export const semver_range = require('../package.json').version;
 
 export
 function is_typedarray(obj) {


### PR DESCRIPTION
In utils.ts, the version string is now set to a valid version, and taken from the package.json. I believe this is the true fix.

labplugin.ts was modified to use the semver from utils.ts instead of index.ts (reason given below). I also added the type signatures to try and catch any typing errors, but I realise that you probably omitted these deliberately (to reduce the lib size when exporting?).

index.ts was modified to remove any non-view/model/exporter exports, so it may be directly used as the `exports` argument to `registerWidget`. I'm not sure if this solves anything - but I could forsee a case where `registerWidget` expects every member of `exports` to be a view/model/exporter class.

I added a version 2 `||` constraint to `@jupyter-widgets/controls`, because the latest version is 2. Not sure if this is correct.

Fixes #321 