### PR TITLE
Bugfix: accept model view instead of promise in `display_view`

### DIFF
--- a/js/src/test/dummy-manager.ts
+++ b/js/src/test/dummy-manager.ts
@@ -65,14 +65,12 @@ class DummyManager extends base.ManagerBase<HTMLElement> {
         this.library = library;
     }
 
-    display_view(msg: services.KernelMessage.IMessage, view_promise: Backbone.View<Backbone.Model>, options: any) {
-        return Promise.resolve(view_promise).then((view) => {
-            this.el.appendChild(view.el);
-            view.on("remove", () => console.log("view removed", view));
-            ( window as any).last_view = view;
-            view.trigger("displayed");
-            return view.el;
-        });
+    display_view(msg: services.KernelMessage.IMessage, view: base.DOMWidgetView, options: any) {
+        this.el.appendChild(view.el);
+        view.on("remove", () => console.log("view removed", view));
+        ( window as any).last_view = view;
+        view.trigger("displayed");
+        return Promise.resolve(view.el);
     }
 
     _get_comm_info() {


### PR DESCRIPTION
Installing `b7f8c1838b075a6e5a023cc957e5d8f99a99faec` fails with `jupyterLab==2.2.5` and `ipywidgets==7.5.1` because this test seems to be out of date.

Dockerfile below
```Dockerfile
FROM ubuntu:latest
ENV DEBIAN_FRONTEND=noninteractive
RUN apt update && apt install --no-install-recommends -y python3-pip python3-venv git curl
RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
RUN apt-get install -y nodejs
WORKDIR /usr/src

RUN useradd -ms /bin/bash jlab
USER jlab
WORKDIR /home/jlab
ENV HOME=/home/jlab

ENV VIRTUAL_ENV $HOME/.env     
RUN python3 -m venv $VIRTUAL_ENV
ENV PATH $VIRTUAL_ENV/bin:$PATH   

RUN pip install jupyterlab bqplot
RUN git clone https://github.com/maartenbreddels/ipyvolume.git -n

WORKDIR $HOME/ipyvolume
RUN git checkout b7f8c1838b075a6e5a023cc957e5d8f99a99faec

RUN pip install -e .
RUN jupyter labextension install bqplot @jupyter-widgets/jupyterlab-manager
RUN jupyter labextension install js 

ENTRYPOINT jupyter lab --no-browser --ip=0.0.0.0 
```