### PR TITLE
feat: discrete transfer functions

### DIFF
--- a/ipyvolume/test_all.py
+++ b/ipyvolume/test_all.py
@@ -9,8 +9,8 @@ import numpy as np
 import pytest
 
 import ipyvolume
-import ipyvolume.pylab as p3
 import ipyvolume as ipv
+import ipyvolume.pylab as p3
 import ipyvolume.examples
 import ipyvolume.datasets
 import ipyvolume.utils
@@ -301,6 +301,15 @@ def test_volshow():
     p3.volshow(x * y * z, opacity=1)
     p3.volshow(x * y * z, level_width=1)
     p3.save("tmp/ipyolume_volume.html")
+
+
+def test_volshow_discrete():
+    boolean_volume = np.random.random((10, 10, 10)) > 0.5
+    ipv.figure()
+    vol = ipv.volshow(boolean_volume)
+    assert isinstance(vol.tf, ipyvolume.TransferFunctionDiscrete)
+    assert len(vol.tf.colors) == 2
+    # int8_volume = np.random.randint(0, 255, size=(10, 10, 10), dtype=np.uint8)
 
 
 def test_volshow_max_shape():

--- a/ipyvolume/transferfunction.py
+++ b/ipyvolume/transferfunction.py
@@ -2,7 +2,7 @@
 
 from __future__ import absolute_import
 
-__all__ = ['TransferFunction', 'TransferFunctionJsBumps', 'TransferFunctionWidgetJs3', 'TransferFunctionWidget3']
+__all__ = ['TransferFunction', 'TransferFunctionDiscrete', 'TransferFunctionJsBumps', 'TransferFunctionWidgetJs3', 'TransferFunctionWidget3']
 
 import numpy as np
 import ipywidgets as widgets  # we should not have widgets under two names
@@ -12,6 +12,7 @@ from traittypes import Array
 
 import ipyvolume._version
 from ipyvolume import serialize
+import ipyvuetify as v
 
 
 N = 1024
@@ -26,9 +27,27 @@ class TransferFunction(widgets.DOMWidget):
     _model_module = Unicode('ipyvolume').tag(sync=True)
     _view_module = Unicode('ipyvolume').tag(sync=True)
     style = Unicode("height: 32px; width: 100%;").tag(sync=True)
+    # rgba should be a 2d array of shape (N, 4), where the last dimension is the rgba value
+    # with values between 0 and 1
     rgba = Array(default_value=None, allow_none=True).tag(sync=True, **serialize.ndarray_serialization)
     _view_module_version = Unicode(semver_range_frontend).tag(sync=True)
     _model_module_version = Unicode(semver_range_frontend).tag(sync=True)
+
+
+class TransferFunctionDiscrete(TransferFunction):
+    _model_name = Unicode('TransferFunctionDiscreteModel').tag(sync=True)
+    colors = traitlets.List(traitlets.Unicode(), default_value=["red", "#0f0"]).tag(sync=True)
+    opacities = traitlets.List(traitlets.CFloat(), default_value=[0.01, 0.01]).tag(sync=True)
+    enabled = traitlets.List(traitlets.Bool(), default_value=[True, True]).tag(sync=True)
+    labels = traitlets.List(traitlets.Unicode(), default_value=["label1", "label2"]).tag(sync=True)
+
+    def control(self):
+        return TransferFunctionDiscreteView(tf=self)
+
+
+class TransferFunctionDiscreteView(v.VuetifyTemplate):
+    template_file = (__file__, 'vue/tf_discrete.vue')
+    tf = traitlets.Instance(TransferFunctionDiscrete).tag(sync=True, **widgets.widget_serialization)
 
 
 class TransferFunctionJsBumps(TransferFunction):

--- a/ipyvolume/vue/tf_discrete.vue
+++ b/ipyvolume/vue/tf_discrete.vue
@@ -1,0 +1,137 @@
+<template>
+    <div class="ipyvolume-tf-root">
+        <v-select v-model="enabled" :items="items" label="Layers" multiple chips clearable>
+        </v-select>
+    </div>
+</template>
+<style id="ipyvolume-tf">
+.ipyvolume-tf-root {
+    display: flex;
+}
+
+.ipyvolume-container-controls {
+    display: flex;
+    flex-direction: column;
+}
+</style>
+
+<script>
+module.export = {
+    data() {
+        return {
+            models: {
+                tf: {
+                }
+            },
+        }
+    },
+    computed: {
+        items: {
+            get: function () {
+                if (!this.models.tf.colors) {
+                    return [];
+                }
+                return this.models.tf.colors.map((k, index) => {
+                    return { text: this.models.tf.labels[index], value: index }
+                });
+            }
+        },
+        enabled: {
+            set: function (val) {
+                const enabled = Array(this.models.tf.colors.length).fill(false);
+                val.forEach((k) => {
+                    enabled[k] = true;
+                })
+                console.log('enabled set', val, enabled);
+                this.models.tf.enabled = enabled;
+            },
+            get: function () {
+                const enabled = [];
+                if (!this.models.tf.enabled) {
+                    return enabled;
+                }
+                this.models.tf.enabled.forEach((k, index) => {
+                    if (k) {
+                        enabled.push(index);
+                    }
+                });
+                console.log('enabled get', enabled);
+                return enabled;
+                // console.log('enabled get', this.models.tf.enabled)
+                // return this.models.tf.enabled;
+            }
+        }
+    },
+    created() {
+        console.log('create tf', this.$refs)
+    },
+
+    mounted() {
+        const figureComponent = this.$refs.figure;
+        (async () => {
+            const tf = await this.viewCtx.getModelById(this.tf.substr(10));
+            function bbproxy(model, attrs, widgetAttrs) {
+                const proxy = {}
+
+                attrs.forEach((attr) => {
+                    console.log('tf setting', attr)
+                    let valueCopy = model.get(attr);
+                    model.on('change:' + attr, (_widget, value) => {
+                        proxy[attr] = value
+                    })
+                    Object.defineProperty(proxy, attr, {
+                        enumerable: true,
+                        configurable: true,
+                        get: () => {
+                            console.log('tf getting', attr, valueCopy);
+                            return valueCopy;
+                        },
+                        set: (value) => {
+                            console.log('tf setting', attr, value);
+                            valueCopy = value;
+                            model.set(attr, value);
+                            model.save_changes();
+                        },
+                    });
+                })
+                if (widgetAttrs) {
+                    Object.keys(widgetAttrs).forEach((attr) => {
+                        console.log('tf setting list', attr)
+                        let listValue = model.get(attr);
+                        let listValueProxy = [];
+                        if (listValue) {
+                            listValueProxy = listValue.map((k) => bbproxy(k, widgetAttrs[attr]));
+                        }
+                        proxy[attr] = listValueProxy;
+                        model.on('change:' + attr, (_widget, value) => {
+                            console.log('tf changed list', attr, value)
+                            if (value) {
+                                proxy[attr] = value.map((k) => bbproxy(k, widgetAttrs[attr]))
+                            } else {
+                                proxy[attr] = null;
+                            }
+                        });
+                        Object.defineProperty(proxy, attr, {
+                            enumerable: true,
+                            configurable: true,
+                            get: () => {
+                                return listValueProxy;
+                            },
+                            set: (value) => {
+                                listValueProxy = value;
+                                console.log('ignore propagating set')
+                            },
+                        });
+                    })
+                }
+
+                return proxy;
+            }
+            this.$set(this.models, 'tf', bbproxy(tf, ['colors', 'enabled', 'labels']));
+        })();
+    },
+    methods: {
+    }
+}
+
+</script>

--- a/requirements_rtd.txt
+++ b/requirements_rtd.txt
@@ -24,3 +24,4 @@ vaex-viz
 docutils==0.17.1
 bokeh
 ipython_genutils
+pydantic<2


### PR DESCRIPTION
Maps integer data to a single color, and gives a dropdown to select which layers to show
Example usage:

```python
ipv.figure()

light = ipv.light_ambient(intensity=0.4);
ipv.light_hemisphere(intensity=1);
tf = ipv.transfer_function_discrete(2, labels=["gap", "solid"], enabled=[False, True], colors=["#ff0000", "#00ff00"])

volume = ipv.volshow(solid, tf=tf)
ipv.show()
```


![discrete-transfer-function](https://github.com/widgetti/ipyvolume/assets/1765949/54b27412-e1fe-447f-ba7e-0220b951d8b7)
