### PR TITLE
build: add ipython_genutils dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,6 +90,7 @@ setup(
         'Pillow',
         'ipywebrtc',
         'requests',
+        'ipython_genutils',
         'ipyvuetify',
         'ipyvue>=1.7.0',
         'pythreejs>=2.4.0',


### PR DESCRIPTION
It fixes import error:

```
import ipyvolume
...
File .../lib/python3.12/site-packages/ipyvolume/serialize.py:17
...
ModuleNotFoundError: No module named 'ipython_genutils'
```

Seems related https://github.com/jupyter/nbconvert/issues/1725